### PR TITLE
Add which-key for keymap discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ lua/plugins/             -- one spec file per concern (lsp, telescope, git, …)
 
 ## Key bindings
 
-Leader is `<Space>`.
+Leader is `<Space>`. Press it and pause to see available mappings via
+[which-key](https://github.com/folke/which-key.nvim).
 
 | Mapping            | Action                          |
 | ------------------ | ------------------------------- |

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -32,5 +32,6 @@
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },
   "undotree": { "branch": "master", "commit": "6fa6b57cda8459e1e4b2ca34df702f55242f4e4d" },
   "vim-fugitive": { "branch": "master", "commit": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0" },
-  "vim-surround": { "branch": "master", "commit": "3d188ed2113431cf8dac77be61b842acb64433d9" }
+  "vim-surround": { "branch": "master", "commit": "3d188ed2113431cf8dac77be61b842acb64433d9" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -1,0 +1,21 @@
+return {
+  {
+    "folke/which-key.nvim",
+    event = "VeryLazy",
+    config = function()
+      local wk = require("which-key")
+      wk.setup()
+
+      -- Label the leader prefixes so the popup groups them clearly
+      wk.add({
+        { "<leader>f", group = "find" },
+        { "<leader>s", group = "search" },
+        { "<leader>g", group = "git" },
+        { "<leader>h", group = "hunks / split" },
+        { "<leader>d", group = "debug" },
+        { "<leader>S", group = "debug step" },
+        { "<leader><leader>", group = "buffers / config" },
+      })
+    end,
+  },
+}


### PR DESCRIPTION
Adds [which-key.nvim](https://github.com/folke/which-key.nvim) so pressing a prefix (e.g. `<Space>`) shows the available mappings.

Group labels registered for the leader prefixes: `find`, `search`, `git`, `hunks / split`, `debug`, `debug step`, and `buffers / config`. Most mappings already carry descriptions (telescope, gitsigns, dap, LSP), so they show up labeled automatically.

### Verification
On Neovim 0.12.4: which-key installs and loads, groups register without error, clean startup message log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)