### PR TITLE
feat(lsp): add call hierarchy keymaps

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -110,6 +110,8 @@ return {
           map("n", "go", vim.lsp.buf.type_definition)
           map("n", "gr", vim.lsp.buf.references)
           map("n", "gs", vim.lsp.buf.signature_help)
+          map("n", "gci", vim.lsp.buf.incoming_calls)
+          map("n", "gco", vim.lsp.buf.outgoing_calls)
           map("n", "gl", vim.diagnostic.open_float)
           map("n", "<F2>", vim.lsp.buf.rename)
           map("n", "<F4>", vim.lsp.buf.code_action)


### PR DESCRIPTION
Adds `gci` / `gco` to the buffer-local LSP keymaps so "who calls this function" and "what does this function call" are reachable from the cursor, instead of typing `:lua vim.lsp.buf.incoming_calls()` by hand.

Both send the LSP `callHierarchy` request for the symbol under the cursor and populate the quickfix list, so results navigate with `:cnext` / `:cprev`. One level at a time — re-run on a result to go deeper.

```lua
map("n", "gci", vim.lsp.buf.incoming_calls)
map("n", "gco", vim.lsp.buf.outgoing_calls)
```

No new dependencies; this is built into `vim.lsp` and works with the servers mason already enables.

**Known tradeoff:** `gc` is the built-in comment operator, so `gc` now waits out `timeoutlen` (1000ms default) to see whether `i` or `o` follows. `gcip` and friends still work, just with a perceptible pause. `<leader>ci` / `<leader>co` would avoid the conflict if the delay proves annoying in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)