### PR TITLE
build: pin stylua config and normalize Lua formatting

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Spaces"
+indent_width = 2
+collapse_simple_statement = "FunctionOnly"

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -2,7 +2,5 @@
 vim.api.nvim_create_autocmd("TextYankPost", {
   desc = "Highlight when yanking (copying) text",
   group = vim.api.nvim_create_augroup("highlight-yank", { clear = true }),
-  callback = function()
-    vim.highlight.on_yank()
-  end,
+  callback = function() vim.highlight.on_yank() end,
 })

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -41,35 +41,45 @@ vim.keymap.set("v", "<leader>P", '"+P')
 vim.keymap.set("n", "<leader>P", '"+p')
 
 -- Telescope (lazily require so it only loads on first use)
-vim.keymap.set("n", "<leader>ps", function()
-  require("telescope.builtin").grep_string({ search = vim.fn.input("Grep > ") })
-end)
+vim.keymap.set(
+  "n",
+  "<leader>ps",
+  function() require("telescope.builtin").grep_string({ search = vim.fn.input("Grep > ") }) end
+)
 vim.keymap.set("n", "<leader>ff", "<cmd>Telescope find_files hidden=true<CR>")
-vim.keymap.set("n", "<leader>fg", function()
-  require("telescope").extensions.live_grep_args.live_grep_args()
-end)
+vim.keymap.set("n", "<leader>fg", function() require("telescope").extensions.live_grep_args.live_grep_args() end)
 vim.keymap.set("n", "<leader>fb", "<cmd>Telescope buffers<CR>")
-vim.keymap.set("n", "<leader>sh", function()
-  require("telescope.builtin").help_tags()
-end, { desc = "[S]earch [H]elp" })
-vim.keymap.set("n", "<leader>sk", function()
-  require("telescope.builtin").keymaps()
-end, { desc = "[S]earch [K]eymaps" })
-vim.keymap.set("n", "<leader>sd", function()
-  require("telescope.builtin").diagnostics()
-end, { desc = "[S]earch [D]iagnostics" })
-vim.keymap.set("n", "<leader>sr", function()
-  require("telescope.builtin").resume()
-end, { desc = "[S]earch [R]esume" })
-vim.keymap.set("n", "<leader><leader><leader>", function()
-  require("telescope.builtin").buffers()
-end, { desc = "[ ] Find existing buffers" })
-vim.keymap.set("n", "<leader>s/", function()
-  require("telescope.builtin").live_grep({
-    grep_open_files = true,
-    prompt_title = "Live Grep in Open Files",
-  })
-end, { desc = "[S]earch [/] in Open Files" })
+vim.keymap.set("n", "<leader>sh", function() require("telescope.builtin").help_tags() end, { desc = "[S]earch [H]elp" })
+vim.keymap.set(
+  "n",
+  "<leader>sk",
+  function() require("telescope.builtin").keymaps() end,
+  { desc = "[S]earch [K]eymaps" }
+)
+vim.keymap.set(
+  "n",
+  "<leader>sd",
+  function() require("telescope.builtin").diagnostics() end,
+  { desc = "[S]earch [D]iagnostics" }
+)
+vim.keymap.set("n", "<leader>sr", function() require("telescope.builtin").resume() end, { desc = "[S]earch [R]esume" })
+vim.keymap.set(
+  "n",
+  "<leader><leader><leader>",
+  function() require("telescope.builtin").buffers() end,
+  { desc = "[ ] Find existing buffers" }
+)
+vim.keymap.set(
+  "n",
+  "<leader>s/",
+  function()
+    require("telescope.builtin").live_grep({
+      grep_open_files = true,
+      prompt_title = "Live Grep in Open Files",
+    })
+  end,
+  { desc = "[S]earch [/] in Open Files" }
+)
 
 -- Git (vim-fugitive)
 vim.keymap.set("n", "<leader>gs", ":Git<CR>")
@@ -85,9 +95,7 @@ vim.keymap.set("n", "<leader>hs", ":split<CR>")
 -- their plugin specs: lua/plugins/editor.lua (conform) and lua/plugins/debug.lua (dap).
 
 -- Toggle colorscheme light/dark
-vim.keymap.set("n", "<leader><leader>cs", function()
-  ChangeTheme()
-end)
+vim.keymap.set("n", "<leader><leader>cs", function() ChangeTheme() end)
 
 -- Terminal mode
 vim.keymap.set("t", "<C-w>n", "<C-\\><C-n>", { desc = "Exit terminal mode" })

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -3,7 +3,12 @@ local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
   local lazyrepo = "https://github.com/folke/lazy.nvim.git"
   local out = vim.fn.system({
-    "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath,
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "--branch=stable",
+    lazyrepo,
+    lazypath,
   })
   if vim.v.shell_error ~= 0 then
     vim.api.nvim_echo({

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -56,9 +56,7 @@ return {
           name = "Launch",
           type = "codelldb",
           request = "launch",
-          program = function()
-            return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/target/debug/", "file")
-          end,
+          program = function() return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/target/debug/", "file") end,
           cwd = "${workspaceFolder}",
           stopOnEntry = false,
         },

--- a/lua/plugins/editor.lua
+++ b/lua/plugins/editor.lua
@@ -10,10 +10,7 @@ return {
       require("nvim-autopairs").setup({})
       local ok, cmp = pcall(require, "cmp")
       if ok then
-        cmp.event:on(
-          "confirm_done",
-          require("nvim-autopairs.completion.cmp").on_confirm_done()
-        )
+        cmp.event:on("confirm_done", require("nvim-autopairs.completion.cmp").on_confirm_done())
       end
     end,
   },
@@ -30,9 +27,7 @@ return {
   {
     "catgoose/nvim-colorizer.lua",
     event = { "BufReadPost", "BufNewFile" },
-    config = function()
-      require("colorizer").setup()
-    end,
+    config = function() require("colorizer").setup() end,
   },
 
   -- Undo history visualizer

--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -10,9 +10,7 @@ return {
       require("gitsigns").setup({
         on_attach = function(bufnr)
           local gs = require("gitsigns")
-          local function map(mode, lhs, rhs, desc)
-            vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, desc = desc })
-          end
+          local function map(mode, lhs, rhs, desc) vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, desc = desc }) end
           map("n", "]h", function() gs.nav_hunk("next") end, "Next git hunk")
           map("n", "[h", function() gs.nav_hunk("prev") end, "Previous git hunk")
           map("n", "<leader>hp", gs.preview_hunk, "Preview hunk")

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -16,9 +16,7 @@ return {
 
       cmp.setup({
         snippet = {
-          expand = function(args)
-            require("luasnip").lsp_expand(args.body)
-          end,
+          expand = function(args) require("luasnip").lsp_expand(args.body) end,
         },
         sources = cmp.config.sources({
           { name = "nvim_lsp" },
@@ -104,9 +102,7 @@ return {
       -- Buffer-local LSP keymaps
       vim.api.nvim_create_autocmd("LspAttach", {
         callback = function(ev)
-          local map = function(mode, lhs, rhs)
-            vim.keymap.set(mode, lhs, rhs, { buffer = ev.buf })
-          end
+          local map = function(mode, lhs, rhs) vim.keymap.set(mode, lhs, rhs, { buffer = ev.buf }) end
           map("n", "K", vim.lsp.buf.hover)
           map("n", "gd", vim.lsp.buf.definition)
           map("n", "gD", vim.lsp.buf.declaration)
@@ -117,9 +113,7 @@ return {
           map("n", "gl", vim.diagnostic.open_float)
           map("n", "<F2>", vim.lsp.buf.rename)
           map("n", "<F4>", vim.lsp.buf.code_action)
-          map({ "n", "x" }, "<F3>", function()
-            vim.lsp.buf.format({ async = true })
-          end)
+          map({ "n", "x" }, "<F3>", function() vim.lsp.buf.format({ async = true }) end)
         end,
       })
     end,

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -3,13 +3,21 @@ return {
     "nvim-treesitter/nvim-treesitter",
     branch = "main",
     lazy = false,
-    build = function()
-      require("nvim-treesitter").update()
-    end,
+    build = function() require("nvim-treesitter").update() end,
     config = function()
       require("nvim-treesitter").install({
-        "vimdoc", "javascript", "typescript", "c", "lua", "rust",
-        "jsdoc", "bash", "ruby", "elixir", "markdown", "markdown_inline",
+        "vimdoc",
+        "javascript",
+        "typescript",
+        "c",
+        "lua",
+        "rust",
+        "jsdoc",
+        "bash",
+        "ruby",
+        "elixir",
+        "markdown",
+        "markdown_inline",
       })
 
       -- Enable treesitter highlighting for any buffer whose parser is available.


### PR DESCRIPTION
## Why

conform runs stylua on `BufWritePre` for Lua (`lua/plugins/editor.lua:44,56`), but the repo has no stylua config — so stylua fell back to its defaults, which use **tabs**. Every save silently retabbed the whole file, burying real changes inside 250-line whitespace diffs. This pins the formatter to the style the config was already written in.

## What

Two commits, separable on review:

1. **`build:`** adds `.stylua.toml` — 3 lines, the actual fix.
2. **`style:`** runs `stylua .` once so format-on-save becomes a no-op and stops ambushing future commits.

## The one judgment call

stylua's default (`collapse_simple_statement = "Never"`) explodes the compact keymap entries in `debug.lua` from 8 readable lines into ~48:

```lua
-- default would turn this:
{ "<leader>dr", function() require("dap").continue() end, desc = "Debug: continue / start" },
-- into 7 lines, x8 keymaps
```

`FunctionOnly` preserves them. The tradeoff is that it collapses a few multi-line callbacks the other way (`autocmds.lua`, `lsp.lua`) — the config was hand-formatted in both styles, and no single setting reproduces both. `FunctionOnly` was the smaller disruption: +66/−61 versus +116/−27.

## Verification

- `stylua --check .` is clean — the formatter no longer rewrites anything.
- All 8 changed files parse.
- `nvim --headless` still loads all 35 plugins.
- `git diff -w` confirms the normalization is whitespace and line-wrapping only; no semantic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)